### PR TITLE
updated to new way of requiring electron

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ npm install --save electron-localshortcut
 
 ```javascript
   const electronLocalshortcut = require('electron-localshortcut');
-  const BrowserWindow = require('browser-window');
+  const BrowserWindow = require('electron').BrowserWindow;
 
   const win = new BrowserWindow();
   win.loadUrl('https://github.com');

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const globalShortcut = require('global-shortcut');
-const BrowserWindow = require('browser-window');
-const app = require('app');
+const electron = require('electron');
+const globalShortcut = electron.globalShortcut;
+const BrowserWindow = electron.BrowserWindow;
+const app = electron.app;
 const windowsWithShortcuts = new WeakMap();
 
 // a placeholder to register shortcuts

--- a/test/index.js
+++ b/test/index.js
@@ -2,9 +2,10 @@
 
 const test = require('tape-async');
 const electronLocalshortcut = require('..');
-const BrowserWindow = require('browser-window');
-const app = require('app');
-const Menu = require('menu');
+const electron = require('electron');
+const BrowserWindow = electron.BrowserWindow;
+const app = electron.app;
+const Menu = electron.menu;
 
 require('electron-debug')();
 


### PR DESCRIPTION
[It’s now done like this](https://github.com/atom/electron/blob/026a1f9a4f9a1512082cd2dbafeb1cbf7e632cd1/docs/api/browser-window.md#browserwindow).