### PR TITLE
fix `unregister()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function unregister(win, accelerator) {
   if (shortcutToUnregisterIdx !== -1) {
     globalShortcut.unregister(accelerator);
     const shortcuts = windowsWithShortcuts.get(win);
-    shortcuts.splice(shortcutToUnregisterIdx);
+    shortcuts.splice(shortcutToUnregisterIdx, 1);
   }
 }
 


### PR DESCRIPTION
```js
electronLocalshortcut.register(win, 'Ctrl+A', () => {
  console.log('You pressed ctrl & A');
});
electronLocalshortcut.register(win, 'Ctrl+B', () => {
  console.log('You pressed ctrl & B');
});

console.log(
  electronLocalshortcut.isRegistered(win, 'Ctrl+A')
);      // true
console.log(
  electronLocalshortcut.isRegistered(win, 'Ctrl+B')
);      // true

electronLocalshortcut.unregister(win, 'Ctrl+A');

console.log(
  electronLocalshortcut.isRegistered(win, 'Ctrl+A')
);      // false
console.log(
  electronLocalshortcut.isRegistered(win, 'Ctrl+B')
);      // false
```

actually, last console log says `false`, but it is not expected.
`ctrl+b` is still registered internally.
and after those, if we call `electronLocalshortcut.unregister(win, 'Ctrl+B'); ` , it doesnt work.
this PR fixes this problem.