### PR TITLE
Add auto-unregistration

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function unregisterAll(win) {
 function register(win, accelerator, callback) {
 	win.on('close', () => {
 		unregisterAllShortcuts(win);
-	})
+	});
 
 	if (arguments.length === 2 && typeof win === 'string') {
 		// register shortcut for any window in the app
@@ -165,7 +165,7 @@ app.on('browser-window-blur', (e, win) => {
 
 app.on('window-all-closed', () => {
 	unregisterAll();
-})
+});
 
 module.exports = {
 	register,

--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ function unregisterAll(win) {
 }
 
 function register(win, accelerator, callback) {
+	win.on('close', () => {
+		unregisterAllShortcuts(win);
+	})
+
 	if (arguments.length === 2 && typeof win === 'string') {
 		// register shortcut for any window in the app
 		// win = accelerator, accelerator = callback
@@ -158,6 +162,10 @@ app.on('browser-window-blur', (e, win) => {
 
 	unregisterAllShortcuts(win);
 });
+
+app.on('window-all-closed', () => {
+	unregisterAll();
+})
 
 module.exports = {
 	register,

--- a/index.js
+++ b/index.js
@@ -45,10 +45,6 @@ function unregisterAll(win) {
 }
 
 function register(win, accelerator, callback) {
-	win.on('close', () => {
-		unregisterAllShortcuts(win);
-	});
-
 	if (arguments.length === 2 && typeof win === 'string') {
 		// register shortcut for any window in the app
 		// win = accelerator, accelerator = callback
@@ -69,6 +65,10 @@ function register(win, accelerator, callback) {
 			accelerator,
 			callback
 		}]);
+		win.on('close', () => {
+			unregisterAllShortcuts(win);
+			console.log('close event below', 2);
+		});
 	}
 
 	const focusedWin = BrowserWindow.getFocusedWindow();
@@ -163,6 +163,8 @@ app.on('browser-window-blur', (e, win) => {
 	unregisterAllShortcuts(win);
 });
 
+// all shortcuts should be unregistered by closing the window.
+// just for double check
 app.on('window-all-closed', () => {
 	unregisterAll();
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-localshortcut",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "register/unregister a keyboard shortcut locally to a BrowserWindow instance, without using a Menu",
   "repository": "parro-it/electron-localshortcut",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,3 @@ Unregisters all of the shortcuts registered on any focused BrowserWindow instanc
 The MIT License (MIT)
 
 Copyright (c) 2016 Andrea Parodi
-
-
-

--- a/test.js
+++ b/test.js
@@ -112,4 +112,3 @@ app.on('ready', () => {
 	win2.show();
 	// win.webContents.openDevTools()
 });
-


### PR DESCRIPTION
Date: Feb 9, 2017

Change:
- All shortcuts registered with a closing window will be unregistered automatically after the window is closed.
- All shortcuts will be unregistered when all windows are closed.

Thanks for code review :)