### PR TITLE
Add support require module in renderer process

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
-const {globalShortcut, BrowserWindow, app} = require('electron');
+const electron = require('electron');
 const isAccelerator = require('electron-is-accelerator');
 const _debug = require('debug');
+
+const {globalShortcut, BrowserWindow, app} = electron.remote || electron;
 
 const debug = _debug('electron-localshortcut');
 const windowsWithShortcuts = new WeakMap();


### PR DESCRIPTION
Due to I'm using webpack for main process and renderer process, and I don't included `node_modules` in packaged app, so I can't use `remote.require`. Just get API by `electron.remote || electron` will be more convenient to me.