### PR TITLE
fix: space event to be compatible with KeyboardEvent

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,10 @@ function _normalizeEvent(input) {
 	if (typeof input.control !== 'undefined') {
 		normalizedEvent.ctrlKey = input.control;
 	}
+	
+	if (input.code === 'Space') {
+		[normalizedEvent.code, normalizedEvent.key] = normalizedEvent.key, normalizedEvent.code;
+	}
 
 	return normalizedEvent;
 }


### PR DESCRIPTION
The issue is the following:
```keyboardevent-from-electron-accelerator``` converts space to normal KeyboardEvent with code Space and key === ' '. 
But when **_onBeforeInput** compares with Electron accelerator Space (with the key Space and code === ' ') ```keyboardevents-areequal``` can not match them.

Fix for #79 
