### PR TITLE
fix: missed isRegistered implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,6 +290,11 @@ function unregister(win, accelerator) {
  */
 function isRegistered(win, accelerator) {
 	_checkAccelerator(accelerator);
+	const wc = win.webContents;
+	const shortcutsOfWindow = windowsWithShortcuts.get(wc);
+	const eventStamp = toKeyEvent(accelerator);
+
+	return _findShortcut(eventStamp, shortcutsOfWindow) !== -1;
 }
 
 module.exports = {


### PR DESCRIPTION
Documentation and implementation for ```isRegistered``` are different.

This PR implements ```isRegistered```.

Fix for #81 