### PR TITLE
Prevent default event action

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,9 @@ const _onBeforeInput = shortcutsOfWindow => (e, input) => {
 	for (const {eventStamp, callback} of shortcutsOfWindow) {
 		if (equals(eventStamp, event)) {
 			debug(`eventStamp: ${eventStamp} match`);
-			callback();
+			if (callback()) {
+				e.preventDefault();
+			}
 
 			return;
 		}


### PR DESCRIPTION
Add support to prevent the default action when the callback returns `true`. E.g:

```js
electronLocalshortcut.register(win, accelerator, () => {
  // ...
  return true // prevent default action
})
```

---

fixes #69