### PR TITLE
Pass original event to callback to preventDefault

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ const _onBeforeInput = shortcutsOfWindow => (e, input) => {
 	for (const {eventStamp, callback} of shortcutsOfWindow) {
 		if (equals(eventStamp, event)) {
 			debug(`eventStamp: ${eventStamp} match`);
-			callback();
+			callback(e);
 
 			return;
 		}


### PR DESCRIPTION
When overriding shortcuts that may have existing functionality, you would need to preventDefault.

By passing the event to the callback, it lets the developer decide what to do!

Suggesting as an alternative to https://github.com/parro-it/electron-localshortcut/pull/92