### PR TITLE
Prevent caught error when using `register(accelerator, callback)` signature

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,7 @@ function register(win, accelerator, callback) {
 		wc = ANY_WINDOW;
 		callback = accelerator;
 		accelerator = win;
+		win = null;
 	} else {
 		wc = win.webContents;
 	}
@@ -169,7 +170,7 @@ function register(win, accelerator, callback) {
 		return;
 	}
 
-	debug(`Registering callback for ${accelerator} on window ${title(win)}`);
+	debug(`Registering callback for ${accelerator} on ${win ? `window "${title(win)}"` : `all windows`}`);
 	_checkAccelerator(accelerator);
 
 	debug(`${accelerator} seems a valid shortcut sequence.`);


### PR DESCRIPTION
Before, when calling `register(accelerator, callback)`, while shuffling the argument variables to convert from the 2-parameter to the 3-parameter signature, `win` was left holding the accelerator string, and this was passed to `title()` which expects a BrowserWindow, generating an error:
```
    TypeError: win.getTitle is not a function
```
The error was caught in `title()`, which returned "A destroyed window", leading (presumably) to an inaccurate debug log.

This was not a serious issue, as `win` was not used further, but even caught errors become a nuisance when debugging with *breaking on caught exceptions* enabled, since you have to skip over them each time you restart the program, to get to the errors you're interested in.

_In full disclosure, I haven't tested this fix, but I'm fairly confident in it._